### PR TITLE
feat(backend-documents): enable document upload with conditional functionalUnitId or buildingId

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "jsonwebtoken": "^9.0.2",
     "lodash": "^4.17.21",
     "mongoose": "^8.6.2",
+    "multer": "^1.4.5-lts.1",
     "nodemailer": "^6.9.15",
     "nodemon": "^3.1.7",
     "swagger-jsdoc": "^6.2.1",

--- a/src/controllers/cloudinary.controller.js
+++ b/src/controllers/cloudinary.controller.js
@@ -1,13 +1,22 @@
 const cloudinary = require('cloudinary').v2
 require('dotenv').config()
 
+const fs = require('fs')
+const util = require('util')
+const unlinkFile = util.promisify(fs.unlink)
+
 const getResourceType = (filePath) => {
-	const extension = filePath.substr(filePath.length - 4)
-	const resourceType = {}
-	if (extension === '.pdf') {
-		resourceType.resource_type = 'raw'
+	const extension = filePath.split('.').pop().toLowerCase()
+
+	if (['jpg', 'jpeg', 'png', 'gif', 'bmp', 'webp'].includes(extension)) {
+		return { resource_type: 'image' }
+	} else if (['mp4', 'avi', 'mov', 'mkv', 'webm'].includes(extension)) {
+		return { resource_type: 'video' }
+	} else if (['pdf'].includes(extension)) {
+		return { resource_type: 'raw' }
+	} else {
+		return { resource_type: 'raw' }
 	}
-	return resourceType
 }
 
 const folderMapping = {
@@ -25,8 +34,8 @@ cloudinary.config({
 
 exports.uploadToCloudinary = async (filePath, type) => {
 	if (!filePath) {
-		console.error('missing file path')
-		return
+		console.error('Missing file path')
+		throw new Error('File path is required')
 	}
 	const resourceType = getResourceType(filePath)
 	const folder = folderMapping[type] || 'Cabildo/otros'
@@ -39,6 +48,7 @@ exports.uploadToCloudinary = async (filePath, type) => {
 		folder,
 		public_id: publicId
 	})
+	await unlinkFile(filePath)
 	return result
 }
 

--- a/src/controllers/fileHosting.controller.js
+++ b/src/controllers/fileHosting.controller.js
@@ -7,6 +7,7 @@ exports.uploadFileToHosting = async (file, type) => {
 		return result
 	} catch (error) {
 		console.error('Error uploading file:', error)
+		throw new Error('Failed to upload file to hosting')
 	}
 }
 
@@ -17,5 +18,6 @@ exports.deleteFileFromHosting = (document) => {
 		return result
 	} catch (error) {
 		console.error('Error deleting file:', error)
+		throw new Error('Failed to delete file from hosting')
 	}
 }

--- a/src/routes/document.routes.js
+++ b/src/routes/document.routes.js
@@ -6,7 +6,11 @@ const documentController = require('../controllers/document.controller')
 router.get('/', documentController.getAllDocuments)
 
 // Create a new document and upload the file to the hosting
-router.post('/createDocument', documentController.createDocument)
+router.post(
+	'/createDocument',
+	documentController.uploadMiddleware,
+	documentController.createDocument
+)
 
 // Get a document by ID
 router.get('/:id', documentController.getDocumentById)
@@ -25,6 +29,5 @@ router.get('/fromBuilding/:id', documentController.getDocumentsFromBuilding)
 
 // Get all documents from a user by ID
 router.get('/fromUser/:id', documentController.getDocumentsFromUser)
-
 
 module.exports = router

--- a/src/services/multer.js
+++ b/src/services/multer.js
@@ -1,0 +1,16 @@
+const multer = require('multer')
+const path = require('path')
+
+// Configurar multer
+const storage = multer.diskStorage({
+	destination: (req, file, cb) => {
+		cb(null, 'uploads/')
+	},
+	filename: (req, file, cb) => {
+		cb(null, Date.now() + path.extname(file.originalname))
+	}
+})
+
+const upload = multer({ storage })
+
+module.exports = upload


### PR DESCRIPTION
- Updated createDocument controller to allow either functionalUnitId or buildingId (one is required).
- Added validation to ensure at least one of functionalUnitId or buildingId is provided in the request body.
- Enhanced error handling to return meaningful messages for missing parameters.
- Refactored logic to assign null to functionalUnitId or buildingId if not present in the request.
- Preserved support for file upload to hosting service and storage of document metadata in MongoDB.